### PR TITLE
Cache API cleanup

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -154,6 +154,8 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      YARN_IGNORE_NODE: 1
 
     steps:
       - if: ${{ matrix.arch == 'arm64' && contains(matrix.image, 'alpine') }}

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -15,6 +15,7 @@ enableGlobalCache: false
 npmPublishAccess: public
 preferDeferredVersions: true
 preferInteractive: true
+pnpFallbackMode: none
 
 packageExtensions:
   "@opentelemetry/instrumentation-mysql2@^0.34.0":

--- a/package.json
+++ b/package.json
@@ -24,10 +24,8 @@
     "vscode": "yarn dlx @yarnpkg/sdks vscode && node scripts/vscode.js && prettier --write .vscode"
   },
   "devDependencies": {
-    "eslint": "^8.45.0",
     "prettier": "^3.0.0",
-    "turbo": "^1.10.10",
-    "typescript": "^5.1.6"
+    "turbo": "^1.10.10"
   },
   "dependenciesMeta": {
     "prettier": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -34,7 +34,8 @@
     "eslint-plugin-jest": "^27.2.3",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-tsdoc": "^0.2.17",
-    "globals": "^13.20.0"
+    "globals": "^13.20.0",
+    "typescript": "^5.1.6"
   },
   "peerDependencies": {
     "eslint": "^8.23.0",

--- a/packages/sdk/src/cache.ts
+++ b/packages/sdk/src/cache.ts
@@ -29,6 +29,16 @@ class Cache {
     return this.spanCache.get(Cache.key(ctx))
   }
 
+  getOrInit(ctx: SpanContext, init: SpanCache = {}): SpanCache {
+    const k = Cache.key(ctx)
+    let c = this.spanCache.get(k)
+    if (!c) {
+      c = init
+      this.spanCache.set(k, c)
+    }
+    return c
+  }
+
   getRoot(ctx: SpanContext): SpanCache | undefined {
     for (;;) {
       const c = this.get(ctx)
@@ -37,33 +47,6 @@ class Cache {
       if (!c.parentId || c.parentRemote) return c
 
       ctx = { ...ctx, traceId: ctx.traceId, spanId: c.parentId }
-    }
-  }
-
-  setParentInfo(
-    ctx: SpanContext,
-    parentInfo: { id?: string; remote?: boolean },
-  ): void {
-    const cache = this.get(ctx)
-    if (cache) {
-      if (parentInfo.id !== undefined) cache.parentId = parentInfo.id
-      if (parentInfo.remote !== undefined)
-        cache.parentRemote = parentInfo.remote
-    } else {
-      this.spanCache.set(Cache.key(ctx), {
-        parentId: parentInfo.id,
-        parentRemote: parentInfo.remote,
-      })
-    }
-  }
-  setTxname(ctx: SpanContext, txname: string): boolean {
-    const cache = this.get(ctx)
-    if (cache) {
-      cache.txname = txname
-      return true
-    } else {
-      this.spanCache.set(Cache.key(ctx), { txname })
-      return false
     }
   }
 

--- a/packages/sdk/src/inbound-metrics-processor.ts
+++ b/packages/sdk/src/inbound-metrics-processor.ts
@@ -51,7 +51,8 @@ export class SwoInboundMetricsSpanProcessor extends NoopSpanProcessor {
     // TODO
     const domain = null
 
-    const transaction = cache.get(context)?.txname ?? defaultTransaction
+    const spanCache = cache.getOrInit(context)
+    const transaction = spanCache.txname ?? defaultTransaction
 
     let txname: string
     if (isHttp) {
@@ -72,7 +73,7 @@ export class SwoInboundMetricsSpanProcessor extends NoopSpanProcessor {
         has_error: hasError ? 1 : 0,
       })
     }
-    cache.setTxname(context, txname)
+    spanCache.txname = txname
   }
 
   private static httpSpanMeta(span: ReadableSpan):

--- a/packages/sdk/src/parent-info-processor.ts
+++ b/packages/sdk/src/parent-info-processor.ts
@@ -28,15 +28,14 @@ export class SwoParentInfoSpanProcessor extends NoopSpanProcessor {
     const spanContext = span.spanContext()
     const parentSpanContext = trace.getSpanContext(parentContext)
 
-    cache.setParentInfo(spanContext, {
-      id: parentSpanContext?.spanId,
-      remote: parentSpanContext?.isRemote,
-    })
+    const spanCache = cache.getOrInit(spanContext)
+    spanCache.parentId = parentSpanContext?.spanId
+    spanCache.parentRemote = parentSpanContext?.isRemote
   }
 
   onEnd(span: ReadableSpan): void {
     const spanContext = span.spanContext()
-    // clear hear unless sampled in which case the collector takes care of it
+    // clear here unless sampled in which case the exporter takes care of it
     if (!(spanContext.traceFlags & TraceFlags.SAMPLED)) {
       cache.clear(spanContext)
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2722,10 +2722,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@solarwinds-apm/solarwinds-apm@workspace:."
   dependencies:
-    eslint: "npm:^8.45.0"
     prettier: "npm:^3.0.0"
     turbo: "npm:^1.10.10"
-    typescript: "npm:^5.1.6"
   dependenciesMeta:
     prettier:
       unplugged: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -2526,6 +2526,7 @@ __metadata:
     eslint-plugin-tsdoc: "npm:^0.2.17"
     globals: "npm:^13.20.0"
     prettier: "npm:^3.0.0"
+    typescript: "npm:^5.1.6"
   peerDependencies:
     eslint: ^8.23.0
     jest: "*"


### PR DESCRIPTION
Replaces the `setXyz` APIs with a `getOrInit` method returning a reference to the cache entry which can then be operated on directly. Sadly I wasn't able to get rid of the singleton architecture since it would make the custom transaction name API very unwieldy.