### PR TITLE
New prerelease

### DIFF
--- a/packages/bindings/npm/linux-arm64-gnu/package.json
+++ b/packages/bindings/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/bindings-linux-arm64-gnu",
-  "version": "1.0.0-pre.1",
+  "version": "1.0.0-pre.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/bindings/npm/linux-arm64-musl/package.json
+++ b/packages/bindings/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/bindings-linux-arm64-musl",
-  "version": "1.0.0-pre.1",
+  "version": "1.0.0-pre.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/bindings/npm/linux-x64-gnu/package.json
+++ b/packages/bindings/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/bindings-linux-x64-gnu",
-  "version": "1.0.0-pre.1",
+  "version": "1.0.0-pre.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/bindings/npm/linux-x64-musl/package.json
+++ b/packages/bindings/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/bindings-linux-x64-musl",
-  "version": "1.0.0-pre.1",
+  "version": "1.0.0-pre.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/bindings",
-  "version": "1.0.0-pre.1",
+  "version": "1.0.0-pre.2",
   "license": "Apache-2.0",
   "contributors": [
     "Raphaël Thériault <raphael.theriault@solarwinds.com>"

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/compat",
-  "version": "1.0.0-pre.1",
+  "version": "1.0.0-pre.2",
   "license": "Apache-2.0",
   "contributors": [
     "Raphaël Thériault <raphael.theriault@solarwinds.com>"

--- a/packages/dependencies/package.json
+++ b/packages/dependencies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/dependencies",
-  "version": "1.0.0-pre.1",
+  "version": "1.0.0-pre.2",
   "license": "Apache-2.0",
   "contributors": [
     "Raphaël Thériault <raphael.theriault@solarwinds.com>"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/eslint-config",
-  "version": "1.0.0-pre.1",
+  "version": "1.0.0-pre.2",
   "license": "Apache-2.0",
   "contributors": [
     "Raphaël Thériault <raphael.theriault@solarwinds.com>"

--- a/packages/histogram/package.json
+++ b/packages/histogram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/histogram",
-  "version": "1.0.0-pre.1",
+  "version": "1.0.0-pre.2",
   "license": "Apache-2.0",
   "contributors": [
     "Raphaël Thériault <raphael.theriault@solarwinds.com>"

--- a/packages/lazy/package.json
+++ b/packages/lazy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/lazy",
-  "version": "1.0.0-pre.1",
+  "version": "1.0.0-pre.2",
   "license": "Apache-2.0",
   "contributors": [
     "Raphaël Thériault <raphael.theriault@solarwinds.com>"

--- a/packages/merged-config/package.json
+++ b/packages/merged-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/merged-config",
-  "version": "1.0.0-pre.1",
+  "version": "1.0.0-pre.2",
   "license": "Apache-2.0",
   "contributors": [
     "Raphaël Thériault <raphael.theriault@solarwinds.com>"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/sdk",
-  "version": "1.0.0-pre.1",
+  "version": "1.0.0-pre.2",
   "license": "Apache-2.0",
   "contributors": [
     "Raphaël Thériault <raphael.theriault@solarwinds.com>"

--- a/packages/solarwinds-apm/package.json
+++ b/packages/solarwinds-apm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solarwinds-apm",
-  "version": "14.0.0-pre.1",
+  "version": "14.0.0-pre.2",
   "description": "OpenTelemetry-based SolarWinds APM library",
   "license": "Apache-2.0",
   "contributors": [

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/test",
-  "version": "0.0.0",
+  "version": "1.0.0-pre.1",
   "license": "Apache-2.0",
   "contributors": [
     "Raphaël Thériault <raphael.theriault@solarwinds.com>"
@@ -46,5 +46,6 @@
   },
   "engines": {
     "node": ">=16.18 <17 || >=18.8 <19 || >=20"
-  }
+  },
+  "stableVersion": "0.0.0"
 }


### PR DESCRIPTION
Mostly so I can test the proxy on both this library and the legacy on at the same time tomorrow

@solarwinds-apm/bindings 1.0.0-pre.2, @solarwinds-apm/compat 1.0.0-pre.2, @solarwinds-apm/dependencies 1.0.0-pre.2, @solarwinds-apm/eslint-config 1.0.0-pre.2, @solarwinds-apm/histogram 1.0.0-pre.2, @solarwinds-apm/lazy 1.0.0-pre.2, @solarwinds-apm/merged-config 1.0.0-pre.2, @solarwinds-apm/sdk 1.0.0-pre.2, @solarwinds-apm/test 1.0.0-pre.1, solarwinds-apm 14.0.0-pre.2