### PR TITLE
Provide tracer and meter providers to registered instrumentations

### DIFF
--- a/.yarn/versions/b53acbb0.yml
+++ b/.yarn/versions/b53acbb0.yml
@@ -1,0 +1,2 @@
+releases:
+  solarwinds-apm: patch


### PR DESCRIPTION
This seems to be required for the Lambda instrumentation to properly flush data but isn't documented anywhere