### PR TITLE
Workflow for publishing testing packages to the Github package registry

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,40 @@
+name: Testing Packages
+on:
+  - workflow_dispatch
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          lfs: true
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: corepack enable
+
+      - uses: actions/cache@v3
+        with:
+          path: .yarn/cache
+          key: yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.zig-build
+            ~/.cache/zig
+          key: zig-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            zig-
+
+      - run: yarn install --immutable
+      - run: yarn version:testing
+      - run: yarn publish
+        env:
+          YARN_NPM_AUTH_TOKEN: ${{ github.token }}
+          YARN_NPM_PUBLISH_REGISTRY: https://npm.pkg.github.com

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "publish": "turbo run build && turbo run lint && turbo run publish",
     "test": "turbo run test --continue",
     "version:latest": "node scripts/version.js",
-    "version:prerelease": "node scripts/version.js pre"
+    "version:prerelease": "node scripts/version.js pre",
+    "version:testing": "node scripts/testing.js"
   },
   "devDependencies": {
     "eslint": "^8.49.0",

--- a/scripts/testing.js
+++ b/scripts/testing.js
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+const fs = require("node:fs")
+const path = require("node:path")
+const cproc = require("node:child_process")
+
+const now = new Date()
+const parts = {
+  year: now.getUTCFullYear().toString().padStart(4, "0"),
+  month: now.getUTCMonth().toString().padStart(2, "0"),
+  day: now.getUTCDate().toString().padStart(2, "0"),
+  hours: now.getUTCHours().toString().padStart(2, "0"),
+  minutes: now.getUTCMinutes().toString().padStart(2, "0"),
+}
+const version = `${parts.year}.${parts.month}.${parts.day}-t.${parts.hours}.${parts.minutes}`
+
+const setVersion = (packageJsonPath) => {
+  const packageJson = JSON.parse(
+    fs.readFileSync(packageJsonPath, { encoding: "utf-8" }),
+  )
+  packageJson.version = version
+  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson))
+  cproc.execSync(`prettier --write ${packageJsonPath}`, { stdio: "inherit" })
+}
+
+const packages = fs.readdirSync("packages")
+for (const p of packages) {
+  const packagePath = path.join("packages", p)
+  setVersion(path.join(packagePath, "package.json"))
+
+  const npmPath = path.join(packagePath, "npm")
+  if (fs.existsSync(npmPath)) {
+    const npmPackages = fs.readdirSync(npmPath)
+    for (const np of npmPackages) {
+      setVersion(path.join(npmPath, np, "package.json"))
+    }
+  }
+}
+
+cproc.execSync("yarn install", { stdio: "inherit" })


### PR DESCRIPTION
Useful for testing small changes that require the packages to be present in a registry without publishing a proper npm prerelease