### PR TITLE
Add AmazonLinux 2023 images and update nodesource repo

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -53,8 +53,7 @@ jobs:
           path: |
             .root
             packages/**/dist/
-            packages/bindings/npm/*/oboe.node
-            packages/bindings/npm/*/metrics.node
+            packages/bindings/npm/*/*.node
             packages/bindings/npm/*/liboboe.so
           retention-days: 1
 
@@ -106,10 +105,12 @@ jobs:
             16-ubi8
             16-ubuntu18.04
             18-alpine
+            18-amazonlinux
             18-debian
             18-ubi
             18-ubuntu
             20-alpine
+            20-amazonlinux
             20-debian
             20-ubi
             20-ubuntu
@@ -136,12 +137,12 @@ jobs:
           - 16-ubi8
           - 16-ubuntu18.04
           - 18-alpine
-          # - 18-amazonlinux - https://github.com/amazonlinux/amazon-linux-2023/issues/365
+          - 18-amazonlinux
           - 18-debian
           - 18-ubi
           - 18-ubuntu
           - 20-alpine
-          # - 20-amazonlinux - https://github.com/amazonlinux/amazon-linux-2023/issues/365
+          - 20-amazonlinux
           - 20-debian
           - 20-ubi
           - 20-ubuntu

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -19,12 +19,12 @@ jobs:
           - 16-ubi8
           - 16-ubuntu18.04
           - 18-alpine
-          # - 18-amazonlinux - https://github.com/amazonlinux/amazon-linux-2023/issues/365
+          - 18-amazonlinux
           - 18-debian
           - 18-ubi
           - 18-ubuntu
           - 20-alpine
-          # - 20-amazonlinux - https://github.com/amazonlinux/amazon-linux-2023/issues/365
+          - 20-amazonlinux
           - 20-debian
           - 20-ubi
           - 20-ubuntu

--- a/docker/16-amazonlinux2.Dockerfile
+++ b/docker/16-amazonlinux2.Dockerfile
@@ -8,7 +8,7 @@ RUN amazon-linux-extras install -y epel && \
     tar \
     xz
 
-RUN curl -fsSL https://rpm.nodesource.com/setup_16.x | bash - && \
+RUN yum install -y https://rpm.nodesource.com/pub_16.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm && \
     yum install -y nodejs && \
     yum clean all
 

--- a/docker/16-ubi8.Dockerfile
+++ b/docker/16-ubi8.Dockerfile
@@ -7,8 +7,8 @@ RUN microdnf install -y \
     tar \
     xz
 
-RUN curl -fsSL https://rpm.nodesource.com/setup_16.x | bash - && \
-    microdnf module disable -y nodejs && \
+RUN microdnf module disable -y nodejs && \
+    microdnf install -y https://rpm.nodesource.com/pub_16.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm && \
     microdnf install -y nodejs && \
     microdnf clean -y all
 

--- a/docker/16-ubi8.Dockerfile
+++ b/docker/16-ubi8.Dockerfile
@@ -1,16 +1,16 @@
-FROM registry.access.redhat.com/ubi8-minimal
+FROM registry.access.redhat.com/ubi8
 
-RUN microdnf install -y \
+RUN dnf install -y \
     curl \
     git \
     git-lfs \
     tar \
     xz
 
-RUN microdnf module disable -y nodejs && \
-    microdnf install -y https://rpm.nodesource.com/pub_16.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm && \
-    microdnf install -y nodejs && \
-    microdnf clean -y all
+RUN dnf module disable -y nodejs && \
+    dnf install -y https://rpm.nodesource.com/pub_16.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm && \
+    dnf install -y nodejs && \
+    dnf clean -y all
 
 RUN corepack enable
 

--- a/docker/16-ubuntu18.04.Dockerfile
+++ b/docker/16-ubuntu18.04.Dockerfile
@@ -4,12 +4,17 @@ RUN apt-get update && apt-get install -y software-properties-common
 
 RUN add-apt-repository ppa:git-core/ppa && \
     apt-get update && apt-get install -y \
+    ca-certificates \
     curl \
     git \
     git-lfs \
+    gnupg \
     xz-utils
 
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
+RUN mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && \
     apt-get install -y nodejs && \
     apt-get clean
 

--- a/docker/18-amazonlinux.Dockerfile
+++ b/docker/18-amazonlinux.Dockerfile
@@ -1,0 +1,17 @@
+FROM amazonlinux
+
+RUN dnf install -y \
+    curl-minimal \
+    git \
+    git-lfs \
+    tar \
+    xz
+
+RUN dnf install -y https://rpm.nodesource.com/pub_18.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm && \
+    dnf install -y nodejs && \
+    dnf clean -y all
+
+RUN corepack enable
+
+WORKDIR /solarwinds-apm
+ENTRYPOINT ["/bin/bash", "-c"]

--- a/docker/18-ubi.Dockerfile
+++ b/docker/18-ubi.Dockerfile
@@ -7,8 +7,8 @@ RUN microdnf install -y \
     tar \
     xz
 
-RUN curl -fsSL https://rpm.nodesource.com/setup_18.x | bash - && \
-    microdnf module disable -y nodejs && \
+RUN microdnf module disable -y nodejs && \
+    microdnf install -y https://rpm.nodesource.com/pub_18.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm && \
     microdnf install -y nodejs && \
     microdnf clean -y all
 

--- a/docker/18-ubi.Dockerfile
+++ b/docker/18-ubi.Dockerfile
@@ -1,16 +1,18 @@
-FROM registry.access.redhat.com/ubi9-minimal
+FROM registry.access.redhat.com/ubi9
 
-RUN microdnf install -y \
+RUN dnf install -y \
     curl-minimal \
     git \
     git-lfs \
     tar \
     xz
 
-RUN microdnf module disable -y nodejs && \
-    microdnf install -y https://rpm.nodesource.com/pub_18.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm && \
-    microdnf install -y nodejs && \
-    microdnf clean -y all
+RUN dnf module disable -y nodejs && \
+    dnf install -y https://rpm.nodesource.com/pub_18.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm && \
+    update-crypto-policies --set LEGACY && \
+    dnf install -y nodejs && \
+    update-crypto-policies --set DEFAULT && \
+    dnf clean -y all
 
 RUN corepack enable
 

--- a/docker/18-ubuntu.Dockerfile
+++ b/docker/18-ubuntu.Dockerfile
@@ -1,12 +1,17 @@
 FROM ubuntu
 
 RUN apt-get update && apt-get install -y \
+    ca-certificates \
     curl \
     git \
     git-lfs \
+    gnupg \
     xz-utils
 
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+RUN mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && \
     apt-get install -y nodejs && \
     apt-get clean
 

--- a/docker/20-amazonlinux.Dockerfile
+++ b/docker/20-amazonlinux.Dockerfile
@@ -1,0 +1,17 @@
+FROM amazonlinux
+
+RUN dnf install -y \
+    curl-minimal \
+    git \
+    git-lfs \
+    tar \
+    xz
+
+RUN dnf install -y https://rpm.nodesource.com/pub_20.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm && \
+    dnf install -y nodejs && \
+    dnf clean -y all
+
+RUN corepack enable
+
+WORKDIR /solarwinds-apm
+ENTRYPOINT ["/bin/bash", "-c"]

--- a/docker/20-ubi.Dockerfile
+++ b/docker/20-ubi.Dockerfile
@@ -7,8 +7,8 @@ RUN microdnf install -y \
     tar \
     xz
 
-RUN curl -fsSL https://rpm.nodesource.com/setup_20.x | bash - && \
-    microdnf module disable -y nodejs && \
+RUN microdnf module disable -y nodejs && \
+    microdnf install -y https://rpm.nodesource.com/pub_20.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm && \
     microdnf install -y nodejs && \
     microdnf clean -y all
 

--- a/docker/20-ubi.Dockerfile
+++ b/docker/20-ubi.Dockerfile
@@ -1,16 +1,18 @@
-FROM registry.access.redhat.com/ubi9-minimal
+FROM registry.access.redhat.com/ubi9
 
-RUN microdnf install -y \
+RUN dnf install -y \
     curl-minimal \
     git \
     git-lfs \
     tar \
     xz
 
-RUN microdnf module disable -y nodejs && \
-    microdnf install -y https://rpm.nodesource.com/pub_20.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm && \
-    microdnf install -y nodejs && \
-    microdnf clean -y all
+RUN dnf module disable -y nodejs && \
+    dnf install -y https://rpm.nodesource.com/pub_20.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm && \
+    update-crypto-policies --set LEGACY && \
+    dnf install -y nodejs && \
+    update-crypto-policies --set DEFAULT && \
+    dnf clean -y all
 
 RUN corepack enable
 

--- a/docker/20-ubuntu.Dockerfile
+++ b/docker/20-ubuntu.Dockerfile
@@ -1,12 +1,17 @@
 FROM ubuntu
 
 RUN apt-get update && apt-get install -y \
+    ca-certificates \
     curl \
     git \
     git-lfs \
+    gnupg \
     xz-utils
 
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+RUN mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && \
     apt-get install -y nodejs && \
     apt-get clean
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -65,6 +65,15 @@ services:
     links:
       - apm-collector
       - otel-collector
+  18-amazonlinux:
+    build:
+      context: .
+      dockerfile: 18-amazonlinux.Dockerfile
+    volumes:
+      - ..:/solarwinds-apm
+    links:
+      - apm-collector
+      - otel-collector
   18-debian:
     build:
       context: .
@@ -97,6 +106,15 @@ services:
     build:
       context: .
       dockerfile: 20-alpine.Dockerfile
+    volumes:
+      - ..:/solarwinds-apm
+    links:
+      - apm-collector
+      - otel-collector
+  20-amazonlinux:
+    build:
+      context: .
+      dockerfile: 20-amazonlinux.Dockerfile
     volumes:
       - ..:/solarwinds-apm
     links:


### PR DESCRIPTION
Adds AmazonLinux 2023 now that it supports `git-lfs`.

nodesource [recently updated](https://github.com/nodesource/distributions?tab=readme-ov-file#new-update-%EF%B8%8F) the way they distribute their Node.js repos, so this PR also addresses that.