### PR TITLE
Fix testing packages workflow

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -40,8 +40,8 @@ jobs:
           git grep -lz '@solarwinds-apm/' | xargs -0 sed -ie 's:@solarwinds-apm/:@${{ github.repository_owner }}/solarwinds-apm-:g'
           git grep -lz -G 'solarwinds-apm[^-]' | xargs -0 sed -rie 's:solarwinds-apm([^-]):@${{ github.repository_owner }}/solarwinds-apm\1:g'
           rm yarn.lock
+          yarn version:testing
           yarn install
           yarn lint:fix
 
-      - run: yarn version:testing
       - run: yarn publish

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,11 +32,12 @@ jobs:
           restore-keys: |
             zig-
 
-      - run: yarn install --immutable
-
       - run: |
           git grep -lz '@solarwinds-apm/' | xargs -0 sed -ie 's:@solarwinds-apm/:@${{ github.repository_owner }}/solarwinds-apm-:g'
           git grep -lz -G 'solarwinds-apm[^-]' | xargs -0 sed -rie 's:solarwinds-apm([^-]):@${{ github.repository_owner }}/solarwinds-apm\1:g'
+          rm yarn.lock
+          yarn install
+
       - run: yarn version:testing
       - run: yarn publish
         env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -41,6 +41,7 @@ jobs:
           git grep -lz -G 'solarwinds-apm[^-]' | xargs -0 sed -rie 's:solarwinds-apm([^-]):@${{ github.repository_owner }}/solarwinds-apm\1:g'
           rm yarn.lock
           yarn install
+          yarn lint:fix
 
       - run: yarn version:testing
       - run: yarn publish

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,6 +33,10 @@ jobs:
             zig-
 
       - run: yarn install --immutable
+
+      - run: |
+          git grep -lz '@solarwinds-apm/' | xargs -0 sed -ie 's:@solarwinds-apm/:@${{ github.repository_owner }}/solarwinds-apm-:g'
+          git grep -lz -G 'solarwinds-apm[^-]' | xargs -0 sed -ie 's:solarwinds-apm[^-]:@${{ github.repository_owner }}/solarwinds-apm:g'
       - run: yarn version:testing
       - run: yarn publish
         env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -7,6 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+    env:
+      YARN_ENABLE_IMMUTABLE_INSTALLS: "false"
+      YARN_NPM_AUTH_TOKEN: ${{ github.token }}
+      YARN_NPM_PUBLISH_REGISTRY: https://npm.pkg.github.com
 
     steps:
       - uses: actions/checkout@v3
@@ -40,6 +44,3 @@ jobs:
 
       - run: yarn version:testing
       - run: yarn publish
-        env:
-          YARN_NPM_AUTH_TOKEN: ${{ github.token }}
-          YARN_NPM_PUBLISH_REGISTRY: https://npm.pkg.github.com

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -36,7 +36,7 @@ jobs:
 
       - run: |
           git grep -lz '@solarwinds-apm/' | xargs -0 sed -ie 's:@solarwinds-apm/:@${{ github.repository_owner }}/solarwinds-apm-:g'
-          git grep -lz -G 'solarwinds-apm[^-]' | xargs -0 sed -iE 's:solarwinds-apm([^-]):@${{ github.repository_owner }}/solarwinds-apm\1:g'
+          git grep -lz -G 'solarwinds-apm[^-]' | xargs -0 sed -rie 's:solarwinds-apm([^-]):@${{ github.repository_owner }}/solarwinds-apm\1:g'
       - run: yarn version:testing
       - run: yarn publish
         env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -37,9 +37,9 @@ jobs:
             zig-
 
       - run: |
+          rm yarn.lock
           git grep -lz '@solarwinds-apm/' | xargs -0 sed -ie 's:@solarwinds-apm/:@${{ github.repository_owner }}/solarwinds-apm-:g'
           git grep -lz -G 'solarwinds-apm[^-]' | xargs -0 sed -rie 's:solarwinds-apm([^-]):@${{ github.repository_owner }}/solarwinds-apm\1:g'
-          rm yarn.lock
           yarn version:testing
           yarn install
           yarn lint:fix

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -36,7 +36,7 @@ jobs:
 
       - run: |
           git grep -lz '@solarwinds-apm/' | xargs -0 sed -ie 's:@solarwinds-apm/:@${{ github.repository_owner }}/solarwinds-apm-:g'
-          git grep -lz -G 'solarwinds-apm[^-]' | xargs -0 sed -ie 's:solarwinds-apm[^-]:@${{ github.repository_owner }}/solarwinds-apm:g'
+          git grep -lz -G 'solarwinds-apm[^-]' | xargs -0 sed -iE 's:solarwinds-apm([^-]):@${{ github.repository_owner }}/solarwinds-apm\1:g'
       - run: yarn version:testing
       - run: yarn publish
         env:

--- a/scripts/testing.js
+++ b/scripts/testing.js
@@ -50,5 +50,3 @@ for (const p of packages) {
     }
   }
 }
-
-cproc.execSync("yarn install", { stdio: "inherit" })


### PR DESCRIPTION
The GitHub npm registry requires packages to be namespaced with the name of the repository owner, so the workflow now does a bunch of search and replace for that.