### PR TITLE
Add TTY check before calling hasColours

### DIFF
--- a/.yarn/versions/36eb5944.yml
+++ b/.yarn/versions/36eb5944.yml
@@ -1,0 +1,5 @@
+releases:
+  "@solarwinds-apm/sdk": patch
+
+declined:
+  - solarwinds-apm

--- a/packages/sdk/src/diag-logger.ts
+++ b/packages/sdk/src/diag-logger.ts
@@ -18,7 +18,7 @@ import * as process from "node:process"
 
 import { type DiagLogFunction, type DiagLogger } from "@opentelemetry/api"
 
-const HAS_COLOURS = process.stdout.hasColors(16)
+const HAS_COLOURS = process.stdout.isTTY && process.stdout.hasColors(16)
 const COLOURS = {
   red: "\x1b[1;31m",
   yellow: "\x1b[1;33m",


### PR DESCRIPTION
Apparently the method is not defined if stdout is not a TTY, which is a bit annoying.