### PR TITLE
Add experimental flags to toggle SW exporters

### DIFF
--- a/.yarn/versions/db656d81.yml
+++ b/.yarn/versions/db656d81.yml
@@ -1,0 +1,2 @@
+releases:
+  solarwinds-apm: minor

--- a/packages/solarwinds-apm/src/config.ts
+++ b/packages/solarwinds-apm/src/config.ts
@@ -155,7 +155,10 @@ const schema = z.object({
 
   experimental: z
     .object({
-      otelCollector: boolean.default(false),
+      otlpTraces: boolean.default(false),
+      otlpMetrics: boolean.default(false),
+      disableSwTraces: boolean.default(false),
+      disableSwMetrics: boolean.default(false),
     })
     .default({}),
 })

--- a/packages/solarwinds-apm/src/config.ts
+++ b/packages/solarwinds-apm/src/config.ts
@@ -157,8 +157,8 @@ const schema = z.object({
     .object({
       otlpTraces: boolean.default(false),
       otlpMetrics: boolean.default(false),
-      disableSwTraces: boolean.default(false),
-      disableSwMetrics: boolean.default(false),
+      swTraces: boolean.default(true),
+      swMetrics: boolean.default(true),
     })
     .default({}),
 })

--- a/packages/solarwinds-apm/src/init.ts
+++ b/packages/solarwinds-apm/src/init.ts
@@ -174,9 +174,11 @@ async function initTracing(
     }),
     resource,
   })
-  provider.addSpanProcessor(spanProcessor)
 
-  if (config.experimental.otelCollector) {
+  if (!config.experimental.disableSwTraces) {
+    provider.addSpanProcessor(spanProcessor)
+  }
+  if (config.experimental.otlpTraces) {
     const otlp = await import("@opentelemetry/exporter-trace-otlp-grpc").catch(
       () => undefined,
     )
@@ -216,9 +218,11 @@ async function initMetrics(
     resource,
     views: config.metrics.views,
   })
-  provider.addMetricReader(reader)
 
-  if (config.experimental.otelCollector) {
+  if (!config.experimental.disableSwMetrics) {
+    provider.addMetricReader(reader)
+  }
+  if (config.experimental.otlpMetrics) {
     const otlp = await import(
       "@opentelemetry/exporter-metrics-otlp-grpc"
     ).catch(() => undefined)

--- a/packages/solarwinds-apm/src/init.ts
+++ b/packages/solarwinds-apm/src/init.ts
@@ -179,18 +179,15 @@ async function initTracing(
     provider.addSpanProcessor(spanProcessor)
   }
   if (config.experimental.otlpTraces) {
-    const otlp = await import("@opentelemetry/exporter-trace-otlp-grpc").catch(
-      () => undefined,
+    const { OTLPTraceExporter } = await import(
+      "@opentelemetry/exporter-trace-otlp-grpc"
     )
-    if (otlp) {
-      const { OTLPTraceExporter } = otlp
-      provider.addSpanProcessor(
-        new BatchSpanProcessor(
-          // configurable through standard OTel environment
-          new OTLPTraceExporter(),
-        ),
-      )
-    }
+    provider.addSpanProcessor(
+      new BatchSpanProcessor(
+        // configurable through standard OTel environment
+        new OTLPTraceExporter(),
+      ),
+    )
   }
 
   provider.register({ propagator })
@@ -223,19 +220,16 @@ async function initMetrics(
     provider.addMetricReader(reader)
   }
   if (config.experimental.otlpMetrics) {
-    const otlp = await import(
+    const { OTLPMetricExporter } = await import(
       "@opentelemetry/exporter-metrics-otlp-grpc"
-    ).catch(() => undefined)
-    if (otlp) {
-      const { OTLPMetricExporter } = otlp
-      provider.addMetricReader(
-        new PeriodicExportingMetricReader({
-          // configurable through standard OTel environment
-          exporter: new OTLPMetricExporter(),
-          exportIntervalMillis: config.metrics.interval,
-        }),
-      )
-    }
+    )
+    provider.addMetricReader(
+      new PeriodicExportingMetricReader({
+        // configurable through standard OTel environment
+        exporter: new OTLPMetricExporter(),
+        exportIntervalMillis: config.metrics.interval,
+      }),
+    )
   }
 
   metrics.setGlobalMeterProvider(provider)

--- a/packages/solarwinds-apm/src/init.ts
+++ b/packages/solarwinds-apm/src/init.ts
@@ -175,7 +175,7 @@ async function initTracing(
     resource,
   })
 
-  if (!config.experimental.disableSwTraces) {
+  if (config.experimental.swTraces) {
     provider.addSpanProcessor(spanProcessor)
   }
   if (config.experimental.otlpTraces) {
@@ -219,7 +219,7 @@ async function initMetrics(
     views: config.metrics.views,
   })
 
-  if (!config.experimental.disableSwMetrics) {
+  if (config.experimental.swMetrics) {
     provider.addMetricReader(reader)
   }
   if (config.experimental.otlpMetrics) {

--- a/packages/solarwinds-apm/test/config.test.ts
+++ b/packages/solarwinds-apm/test/config.test.ts
@@ -84,10 +84,12 @@ describe("readConfig", () => {
   })
 
   it("parses experimental env", () => {
-    process.env.SW_APM_EXPERIMENTAL_OTEL_COLLECTOR = "true"
+    process.env.SW_APM_EXPERIMENTAL_OTLP_TRACES = "true"
+    process.env.SW_APM_EXPERIMENTAL_SW_METRICS = "0"
 
     const config = readConfig()
-    expect(config.experimental.otelCollector).to.be.true
+    expect(config.experimental.otlpTraces).to.be.true
+    expect(config.experimental.swMetrics).to.be.false
   })
 
   it("throws on bad boolean", () => {

--- a/packages/solarwinds-apm/test/config.test.ts
+++ b/packages/solarwinds-apm/test/config.test.ts
@@ -43,7 +43,12 @@ describe("readConfig", () => {
       insertTraceContextIntoQueries: false,
       instrumentations: {},
       metrics: { interval: 60_000 },
-      experimental: { otelCollector: false },
+      experimental: {
+        otlpTraces: false,
+        otlpMetrics: false,
+        swTraces: true,
+        swMetrics: true,
+      },
     }
 
     expect(config).to.deep.include(expected)


### PR DESCRIPTION
Also split the OTLP flags between traces and metrics and throw if missing the proper packages for OTLP export instead of silently failing.